### PR TITLE
🐛 Navigation Bars Stacked

### DIFF
--- a/ngfire/files/src/lib/file-manager/components/file-manager-breadcrumbs/file-manager-breadcrumbs.component.html
+++ b/ngfire/files/src/lib/file-manager/components/file-manager-breadcrumbs/file-manager-breadcrumbs.component.html
@@ -1,5 +1,5 @@
 <div class="breadcrumb-navbar" fxLayout="row" fxLayoutAlign="start center" *ngIf="crumbs$ | async as crumbs">
-  <i (click)="goBack()" *ngIf="crumbs.length > 1" class="fas fa-arrow-left back-ic"></i>
+  <div (click)="goBack()" *ngIf="crumbs.length > 1" class="fas fa-arrow-left back-ic"></div>
 
   <div class="breadcrumbs" fxLayout="row">
     <div class="breadcrumb-holder" *ngFor="let crumb of crumbs; let i = index">


### PR DESCRIPTION
Navigation bars were stacked on one another.

Link to bug: https://www.notion.so/syndic4you/Navigation-arrows-are-stacked-one-near-another-when-navigating-to-subfolders-in-the-Documents-page-0c0a31cd09094b3693db71abfa39785b