### PR TITLE
🐛disable changing suppliers when updating supplier details.

### DIFF
--- a/iote/bricks-angular/src/lib/material-form-bricks/components/autocomplete-action-field/autocomplete-action-field.component.html
+++ b/iote/bricks-angular/src/lib/material-form-bricks/components/autocomplete-action-field/autocomplete-action-field.component.html
@@ -4,7 +4,7 @@
 
   <span matPrefix *ngIf="icon"><i [class]="icon"></i>&nbsp;&nbsp;</span>
 
-  <input matInput [type]="inputType"
+  <input matInput [type]="inputType" [disabled]="isDisableSupplier"
          [matAutocomplete]="auto"
          [(ngModel)]="selectedItemNow" (keyup)="onType($event)" (change)="onTypeSelectedItem($event)"
          [required]="required" />

--- a/iote/bricks-angular/src/lib/material-form-bricks/components/autocomplete-action-field/autocomplete-action-field.component.ts
+++ b/iote/bricks-angular/src/lib/material-form-bricks/components/autocomplete-action-field/autocomplete-action-field.component.ts
@@ -17,6 +17,7 @@ export class AutocompleteActionFieldComponent<T> implements OnInit, OnChanges
   @Input() required: boolean;
   @Input() icon :string;
   @Input() inputType :string = 'text';
+  @Input() isDisableSupplier : boolean;
 
   @Output() itemSelected = new EventEmitter<T>();
   @Output() newItemTyped  = new EventEmitter<string>();


### PR DESCRIPTION
Disable changing the supplier input field when updating an invoice.